### PR TITLE
Quick fix

### DIFF
--- a/tests/test_to_json.py
+++ b/tests/test_to_json.py
@@ -1,5 +1,27 @@
+import xobjects as xo
+
+
+
 def test_to_json():
-    import xobjects as xo
+
+    class A(xo.Struct):
+        a = xo.Float64[:]
+        b = xo.Int64
+
+    class Uref(xo.UnionRef):
+        _reftypes = (A,)
+
+    x = A(a=[2,3], b=1)
+    u = Uref(x)
+    v = Uref(*u._to_json())
+
+    assert v.get().a[0] == 2
+    assert v.get().a[1] == 3
+    assert v.get().b == 1
+
+
+
+def test_to_json_array():
 
     class A(xo.Struct):
         a = xo.Float64[:]

--- a/xobjects/ref.py
+++ b/xobjects/ref.py
@@ -297,10 +297,10 @@ class UnionRef(metaclass=MetaUnionRef):
 
     def _to_json(self):
         v = self.get()
-        w = v
+        classname = v.__class__.__name__
         if hasattr(v, "_to_json"):
-            w = v._to_json()
-        return (v.__class__.__name__, w)
+            v = v._to_json()
+        return (classname, v)
 
 
 def is_ref(atype):

--- a/xobjects/ref.py
+++ b/xobjects/ref.py
@@ -297,9 +297,10 @@ class UnionRef(metaclass=MetaUnionRef):
 
     def _to_json(self):
         v = self.get()
+        w = v
         if hasattr(v, "_to_json"):
-            v = v._to_json()
-        return (self.get().__class__.__name__, v)
+            w = v._to_json()
+        return (v.__class__.__name__, w)
 
 
 def is_ref(atype):

--- a/xobjects/ref.py
+++ b/xobjects/ref.py
@@ -131,21 +131,21 @@ class MetaUnionRef(type):
             if tt.__name__ == typ.__name__:
                 return ii
         # If no match found:
-        raise TypeError(f"{typ} is not memberof {cls}!")
+        raise TypeError(f"{typ} is not member of {cls}!")
 
     def _typeid_from_name(cls, name):
         for ii, tt in enumerate(cls._reftypes):
             if tt.__name__ == name:
                 return ii
         # If no match found:
-        raise TypeError(f"{name} is not memberof {cls}")
+        raise TypeError(f"{name} is not member of {cls}")
 
     def _type_from_name(cls, name):
         for tt in cls._reftypes:
             if tt.__name__ == name:
                 return tt
         # If no match found:
-        raise TypeError(f"{name} is not memberof {cls}")
+        raise TypeError(f"{name} is not member of {cls}")
 
     def _type_from_typeid(cls, typeid):
         for ii, tt in enumerate(cls._reftypes):
@@ -299,7 +299,7 @@ class UnionRef(metaclass=MetaUnionRef):
         v = self.get()
         if hasattr(v, "_to_json"):
             v = v._to_json()
-        return (self.__class__.__name__, v)
+        return (self.get().__class__.__name__, v)
 
 
 def is_ref(atype):


### PR DESCRIPTION
Quick fix: in `UnionRef._to_json()` the returned class name should be that of the underlying type.

Without this fix, the returned class name will be that of the `UnionRef` itself, failing to instantiate a new `UnionRef` from this json ("`TypeError: Uref is not member of <unionref Uref>`").

This passed unnoticed as it works correctly for an array of `UnionRef`, hence I added a test for the bare `UnionRef` as well to catch this in the future.

As a side remark: it is possible to instantiate an array of `UnionRef` directly from a list of `tuple`, though this is not possible for a bare `UnionRef` where the `tuple` has to be unpacked. Is this intentional? Similarly, the underlying `XoStruct` fields can be directly accessed in case of an array of `UnionRef`, while one has to call `.get()` on the bare `UnionRef`.

The difference between these two can be clearly seen in the two tests inside `test_to_json.py`. This is not an issue, though it might be interesting to homogenise the API.